### PR TITLE
feat: Handle wrapped components

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ import { styled } from '@glitz/react';
 const CompactHeader = styled.div({
   backgroundColor: 'palevioletred',
 });
+const NarrowHeader = styled(CompactHeader, {
+  backgroundColor: 'mediumslateblue',
+});
 ```
 
 To this:
@@ -23,6 +26,10 @@ const CompactHeader = styled.div({
   backgroundColor: 'palevioletred',
 });
 CompactHeader.displayName = 'CompactHeader';
+const NarrowHeader = styled(CompactHeader, {
+  backgroundColor: 'mediumslateblue',
+});
+NarrowHeader.displayName = 'NarrowHeader';
 ```
 
 ### WIP

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ function visitNode(
   if (ts.isVariableStatement(node)) {
     const decl = node.declarationList.declarations[0];
 
+    // Styled HTML component
     if (
       decl.initializer &&
       ts.isIdentifier(decl.name) &&
@@ -69,6 +70,27 @@ function visitNode(
       decl.initializer.expression.expression &&
       ts.isIdentifier(decl.initializer.expression.expression) &&
       decl.initializer.expression.expression.escapedText === 'styled'
+    ) {
+      const variableDeclarationName = decl.name.escapedText.toString();
+      return [
+        node,
+        ts.createStatement(
+          ts.createAssignment(
+            ts.createPropertyAccess(ts.createIdentifier(variableDeclarationName), 'displayName'),
+            ts.createStringLiteral(variableDeclarationName),
+          ),
+        ),
+      ];
+    }
+
+    // Wrapped glitz component
+    if (
+      decl.initializer &&
+      ts.isIdentifier(decl.name) &&
+      ts.isCallExpression(decl.initializer) &&
+      ts.isIdentifier(decl.initializer.expression) &&
+      decl.initializer.expression.escapedText === 'styled' &&
+      decl.initializer.arguments.length > 0
     ) {
       const variableDeclarationName = decl.name.escapedText.toString();
       return [

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -2,7 +2,7 @@ import compile from './compile';
 
 type Code = { [fileName: string]: string };
 
-test('creates displayName for Glitz components', () => {
+test('creates displayName for Glitz html components', () => {
   const code = {
     'component1.tsx': `
 import { styled } from "@glitz/react";
@@ -33,6 +33,27 @@ MyStyledComponent.displayName = "MyStyledComponent";
 function testFunction() {
     const isNotTopLevelDeclaration = true;
 }`,
+  };
+
+  expectEqual(expected, compile(code));
+});
+test('creates displayName for wrapped Glitz components', () => {
+  const code = {
+    'component1.tsx': `
+import { styled } from "@glitz/react";
+const BaseComponent = styled.div({ background: 'red' });
+const ChildComponent = styled(BaseComponent, { background: 'red' });
+`,
+  };
+
+  const expected = {
+    'component1.jsx': `
+import { styled } from "@glitz/react";
+const BaseComponent = styled.div({ background: 'red' });
+BaseComponent.displayName = "BaseComponent";
+const ChildComponent = styled(BaseComponent, { background: 'red' });
+ChildComponent.displayName = "ChildComponent";
+    `,
   };
 
   expectEqual(expected, compile(code));


### PR DESCRIPTION
Add support for adding a display name for wrapped components.

E.g.:

```js
const NarrowHeader = styled(CompactHeader, {
  backgroundColor: 'mediumslateblue',
});
```

becomes:

```js
const NarrowHeader = styled(CompactHeader, {
  backgroundColor: 'mediumslateblue',
});
NarrowHeader.displayName = 'NarrowHeader';
```